### PR TITLE
Fix sender_email when not the same as smtp_username

### DIFF
--- a/smtp_functions.py
+++ b/smtp_functions.py
@@ -42,8 +42,6 @@ def send_email(error: str, config: Dynaconf) -> None:
     msg.set_content(error)
 
     sender_email = config.notification.email_sender
-    if "smtp_username" in config.notification:
-        sender_email = config.notification.smtp_username
 
     try:
         smtp_conn = create_connection_and_log_user(config)


### PR DESCRIPTION
In my case : 

```
sender_email = somebody@domain.com
smtp_username = somebody
```

Considering that with: 

```
sender_email = somebody 
```

I get SMTP Error 501 5.1.7 Invalid address

And with: 

```
smtp_username = somebody@domain.com
```

I get an authentication error.

It seems not possible to get emails working without removing this line.
IMHO anyone can correctly configure `sender_email`, even when using `smtp_username`.
Or we should use `smtp_username` as sender only if sender is not set.