### PR TITLE
Do not mask original SMTP error

### DIFF
--- a/smtp_functions.py
+++ b/smtp_functions.py
@@ -51,4 +51,4 @@ def send_email(error: str, config: Dynaconf) -> None:
         smtp_conn.quit()
         logging.debug("Notification email sent.")
     except:
-        logging.debug("Failed to send notification email!")
+        logging.exception("Failed to send notification email!")


### PR DESCRIPTION
IMHO more interesting having in logs: 

```
Traceback (most recent call last):
File "/mergin-db-sync/smtp_functions.py", line 50, in send_email
smtp_conn.sendmail(sender_email, config.notification.email_recipients, msg.as_string())
File "/usr/lib/python3.8/smtplib.py", line 880, in sendmail
raise SMTPSenderRefused(code, resp, from_addr)
smtplib.SMTPSenderRefused: (501, b'5.1.7 Invalid address', 'svc-mergin-maps-smtp')
```

than:

```
Failed to send notification email!
```